### PR TITLE
Added MInvariant, for invariant functors in the category of monads.

### DIFF
--- a/Control/Monad/Morph.hs
+++ b/Control/Monad/Morph.hs
@@ -44,6 +44,8 @@
 {-# LANGUAGE Rank2Types #-}
 
 module Control.Monad.Morph (
+    -- * Invariant functors over Monads
+    MInvariant(..),
     -- * Functors over Monads
     MFunctor(..),
     generalize,

--- a/Control/Monad/Morph.hs
+++ b/Control/Monad/Morph.hs
@@ -100,7 +100,7 @@ import Data.Functor.Identity (Identity)
 {-| An invariant functor in the category of monads, using 'hoistiso' as the
 analog of @invmap@:
 
-> hoistiso (f, g) . hoistiso (f', g') = hoistiso (f . f', g' . g)
+> hoistiso f g . hoistiso f' g' = hoistiso (f . f') (g' . g)
 > 
 > hoistiso id id = id
 -}
@@ -144,6 +144,18 @@ instance MInvariant (W.WriterT w) where
     hoistiso nat _ = hoist nat
 
 instance MInvariant (W'.WriterT w) where
+    hoistiso nat _ = hoist nat
+
+instance Functor f => MInvariant (Compose f) where
+    hoistiso nat _ = hoist nat
+
+instance MInvariant (Product f) where
+    hoistiso nat _ = hoist nat
+
+instance MInvariant Backwards where
+    hoistiso nat _ = hoist nat
+
+instance MInvariant Lift where
     hoistiso nat _ = hoist nat
 
 {-| A functor in the category of monads, using 'hoist' as the analog of 'fmap':


### PR DESCRIPTION
Hi Gabriel,

I wonder would I be able to persuade you to add the `MInvariant` class to your `mmorph` package? I've implemented it below. While some monad transformers can't be made an instance of `MFunctor`, every monad transformer (even `ContT` and similar) can be made an instance of `MInvariant`. Unfortunately this is a breaking change, because I have made `MInvariant` a superclass of `MFunctor`.

The reason I'm asking is because it would simplify the implementation of my `layers` package, which as it stands contains some overlap in functionality with `mmorph`. With this change I could simply depend on `mmorph` rather than reimplementing the wheel for this functionality.

If you are considering merging this patch, feel free to change any of the named I've chosen, and you might also want to update the documentation as well. At the moment I'm just trying to see if you would have any interest in this.

Thanks,
Shane
