### PR TITLE
Derive Eq, Ord, Read, Show for ComposeT

### DIFF
--- a/src/Control/Monad/Trans/Compose.hs
+++ b/src/Control/Monad/Trans/Compose.hs
@@ -24,6 +24,7 @@ infixr 9 `ComposeT`
 -- | Composition of monad transformers.
 newtype ComposeT (f :: (* -> *) -> * -> *) (g :: (* -> *) -> * -> *) m a
     = ComposeT { getComposeT :: f (g m) a }
+  deriving (Eq, Ord, Read, Show)
 
 instance (MFunctor f, MonadTrans f, MonadTrans g) => MonadTrans (ComposeT f g)
   where


### PR DESCRIPTION
Since (1) `Compose` has these, and (2) the `Show` instance is especially useful for debugging.