### PR TITLE
Add instances for typeclasses in mtl

### DIFF
--- a/mmorph.cabal
+++ b/mmorph.cabal
@@ -20,6 +20,7 @@ Library
     Hs-Source-Dirs: src
     Build-Depends:
         base         >= 4       && < 5  ,
+        mtl          >= 2.0.1   && < 2.3,
         transformers >= 0.2.0.0 && < 0.6
     Exposed-Modules: Control.Monad.Morph, Control.Monad.Trans.Compose
     GHC-Options: -O2

--- a/src/Control/Monad/Trans/Compose.hs
+++ b/src/Control/Monad/Trans/Compose.hs
@@ -1,4 +1,8 @@
-{-# LANGUAGE FlexibleContexts, KindSignatures #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {-| Composition of monad transformers. A higher-order version of
     "Data.Functor.Compose".
@@ -7,13 +11,20 @@
 module Control.Monad.Trans.Compose (
     -- * ComposeT
     ComposeT(ComposeT, getComposeT),
+    mapComposeT
    ) where
 
 import Control.Applicative (
     Applicative(pure, (<*>), (*>), (<*)), Alternative(empty, (<|>)) )
 import Control.Monad (MonadPlus(mzero, mplus), liftM)
+import Control.Monad.Cont.Class (MonadCont(callCC))
+import Control.Monad.Error.Class (MonadError(throwError, catchError))
 import Control.Monad.Morph (MFunctor(hoist))
+import Control.Monad.RWS.Class (MonadRWS)
+import Control.Monad.Reader.Class (MonadReader(ask, local, reader))
+import Control.Monad.State.Class (MonadState(get, put, state))
 import Control.Monad.Trans.Class (MonadTrans(lift))
+import Control.Monad.Writer.Class (MonadWriter(writer, tell, listen, pass))
 import Control.Monad.IO.Class (MonadIO(liftIO))
 import Data.Foldable (Foldable(fold, foldMap, foldr, foldl, foldr1, foldl1))
 import Data.Traversable (Traversable(traverse, sequenceA, mapM, sequence))
@@ -67,3 +78,32 @@ instance Traversable (f (g m)) => Traversable (ComposeT f g m) where
     sequenceA  (ComposeT m) = fmap  ComposeT (sequenceA  m)
     mapM     f (ComposeT m) = liftM ComposeT (mapM     f m)
     sequence   (ComposeT m) = liftM ComposeT (sequence   m)
+
+instance MonadCont (f (g m)) => MonadCont (ComposeT f g m) where
+    callCC f = ComposeT $ callCC $ \c -> getComposeT (f (ComposeT . c))
+
+instance MonadError e (f (g m)) => MonadError e (ComposeT f g m) where
+    throwError     = ComposeT . throwError
+    catchError m h = ComposeT $ catchError (getComposeT m) (getComposeT . h)
+
+instance MonadRWS r w s (f (g m)) => MonadRWS r w s (ComposeT f g m)
+
+instance MonadReader r (f (g m)) => MonadReader r (ComposeT f g m) where
+    ask    = ComposeT ask
+    local  = mapComposeT . local
+    reader = ComposeT . reader
+
+instance MonadState s (f (g m)) => MonadState s (ComposeT f g m) where
+    get   = ComposeT get
+    put   = ComposeT . put
+    state = ComposeT . state
+
+instance MonadWriter w (f (g m)) => MonadWriter w (ComposeT f g m) where
+    writer = ComposeT . writer
+    tell   = ComposeT . tell
+    listen = mapComposeT listen
+    pass   = mapComposeT pass
+
+-- | Transform the computation inside a 'ComposeT'.
+mapComposeT :: (f (g m) a -> p (q n) b) -> ComposeT f g m a -> ComposeT p q n b
+mapComposeT f = ComposeT . f . getComposeT


### PR DESCRIPTION
This adds `MonadCont`, `MonadError`, `MonadRWS`, `MonadReader`, `MonadState`, and `MonadWriter` instances for `ComposeT`. With these instances, it's now much easier to `GeneralizedNewtypeDeriving` your way to a a fully functional monad transformer stack:

```haskell
newtype Stack m a = Stack ((ReaderT Int `ComposeT` StateT Bool `ComposeT` WriterT String) m a)
  deriving ( Functor
           , Applicative
           , Monad
           , MonadTrans
           , MonadReader Int
           , MonadState Bool
           , MonadWriter String
           )
```