### PR TITLE
Tighten lower bound on `mtl`

### DIFF
--- a/mmorph.cabal
+++ b/mmorph.cabal
@@ -20,7 +20,7 @@ Library
     Hs-Source-Dirs: src
     Build-Depends:
         base                >= 4       && < 5  ,
-        mtl                 >= 2.0.1   && < 2.3,
+        mtl                 >= 2.1     && < 2.3,
         transformers        >= 0.2.0.0 && < 0.6,
         transformers-compat >= 0.3     && < 0.6
     Exposed-Modules: Control.Monad.Morph, Control.Monad.Trans.Compose


### PR DESCRIPTION
A counter-example would be w/ `mtl-2.0.1.1`:

```
Preprocessing library for mmorph-1.0.9..
Building library for mmorph-1.0.9..
[2 of 2] Compiling Control.Monad.Trans.Compose ( src/Control/Monad/Trans/Compose.hs, /tmp/mmorph-1.0.9/dist-newstyle/build/x86_64-linux/ghc-7.4.2/mmorph-1.0.9/build/Control/Monad/Trans/Compose.o )

src/Control/Monad/Trans/Compose.hs:24:36:
    Module
    `Control.Monad.Reader.Class'
    does not export
    `MonadReader(ask, local, reader)'

src/Control/Monad/Trans/Compose.hs:25:35:
    Module
    `Control.Monad.State.Class'
    does not export
    `MonadState(get, put, state)'

src/Control/Monad/Trans/Compose.hs:27:36:
    Module
    `Control.Monad.Writer.Class'
    does not export
    `MonadWriter(writer, tell, listen, pass)'
```