### PR TITLE
Only enable PolyKinds on GHC 7.6+

### DIFF
--- a/src/Control/Monad/Morph.hs
+++ b/src/Control/Monad/Morph.hs
@@ -1,4 +1,8 @@
-{-# LANGUAGE CPP, RankNTypes, PolyKinds #-}
+{-# LANGUAGE CPP, RankNTypes #-}
+
+#if __GLASGOW_HASKELL__ >= 706
+{-# LANGUAGE PolyKinds #-}
+#endif
 
 {-| A monad morphism is a natural transformation:
 


### PR DESCRIPTION
Currently, `PolyKinds` is enabled unconditionally, which prevents `mmorph` from building on older versions of GHC that do not support `PolyKinds` at all (or do not support them reliably).

This restricts the use of `PolyKinds` to 7.6+, which was the first GHC release to have reliable support for `PolyKinds`.