### PR TITLE
MonadFail compatibility with GHC 8.8.

### DIFF
--- a/src/Control/Monad/Trans/Compose.hs
+++ b/src/Control/Monad/Trans/Compose.hs
@@ -68,7 +68,14 @@ instance Alternative (f (g m)) => Alternative (ComposeT f g m) where
 instance Monad (f (g m)) => Monad (ComposeT f g m) where
     return a = ComposeT (return a)
     m >>= f  = ComposeT (getComposeT m >>= \x -> getComposeT (f x))
+#if __GLASGOW_HASKELL__ < 808
     fail e   = ComposeT (fail e)
+#endif
+
+#if __GLASGOW_HASKELL__ >= 800
+instance MonadFail (f (g m)) => MonadFail (ComposeT f g m) where
+    fail e   = ComposeT (fail e)
+#endif
 
 instance MonadPlus (f (g m)) => MonadPlus (ComposeT f g m) where
     mzero = ComposeT mzero


### PR DESCRIPTION
With this change, I can compile on the alpha release of 8.8.1.  Also, this adds `MonadFail` instances for other GHC versions in the 8.x series.