### PR TITLE
Restore missing `Traversable` instance

### DIFF
--- a/src/Control/Monad/Trans/Compose.hs
+++ b/src/Control/Monad/Trans/Compose.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE CPP #-}
 
 #if __GLASGOW_HASKELL__ >= 806
@@ -51,6 +52,7 @@ newtype ComposeT (f :: (* -> *) -> * -> *) (g :: (* -> *) -> * -> *) m a
     , Ord
     , Read
     , Show
+    , Traversable
     , Monad
     , MonadCont
     , MonadError e


### PR DESCRIPTION
… as caught by @phadej in #57

This instance was omitted by mistake when refactoring the
`Control.Monad.Trans.Compose` module to use `GeneralizedNewtypeDeriving`
in #52